### PR TITLE
new django command for deleting old notifications

### DIFF
--- a/notifications/management/commands/delete_expired_notifications.py
+++ b/notifications/management/commands/delete_expired_notifications.py
@@ -1,0 +1,36 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from notifications.models import Notification
+
+
+class Command(BaseCommand):
+    help = "custom django command to delete expired notifications after exceeding a specified time period"
+    
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--period",
+            type=int,
+            default=30,
+            help="time period in days"
+        )
+
+    def handle(self, *args, **options):
+        n_days_provided = options["period"]
+        
+        print(
+            f"\n start deleting notifications older than {n_days_provided} days ...\n"
+        )
+
+        expired_notifications = Notification.objects.exclude(
+            created_at__gt=timezone.now() - timedelta(days=n_days_provided)
+        )
+
+        n_expired_notifications = expired_notifications.count()
+        expired_notifications.delete()
+
+        print(
+            f"\n--- {n_expired_notifications} expired notifications are deleted from the database ---\n"
+        )


### PR DESCRIPTION
As many web apps keep notifications in their database for certain amount of time (e.g. facebook by default keeps notifications for 7 days) 

This command deletes notifications from the database that are older than the specified number of days.

## Usage 
run `python manage.py remove_expired_notifications  --period=number of days` default=30 days

## Follow up
one can either run the command manually or by using a scheduler that run the  command periodically. 

For more info on scheduler see this [post](https://stackoverflow.com/questions/11788821/best-way-to-delete-a-django-model-instance-after-a-certain-date)